### PR TITLE
Fix for overaligned typedef structures (7.4.0)

### DIFF
--- a/gcc/config/mips/mips.c
+++ b/gcc/config/mips/mips.c
@@ -7280,6 +7280,21 @@ mips_arg_partial_bytes (cumulative_args_t cum,
   return info.stack_words > 0 ? info.reg_words * UNITS_PER_WORD : 0;
 }
 
+/* Given MODE and TYPE of a function argument, return the alignment in
+   bits. In case of typedef, alignment of its original type is
+   used.  */
+static unsigned int
+mips_function_arg_alignment (machine_mode mode, const_tree type)
+{
+  if (!type)
+    return GET_MODE_ALIGNMENT (mode);
+
+  if (is_typedef_decl (TYPE_NAME (type)))
+    type = DECL_ORIGINAL_TYPE (TYPE_NAME (type));
+
+  return TYPE_ALIGN (type);
+}
+
 /* Implement TARGET_FUNCTION_ARG_BOUNDARY.  Every parameter gets at
    least PARM_BOUNDARY bits of alignment, but will be given anything up
    to STACK_BOUNDARY bits if the type requires it.  */
@@ -7288,8 +7303,8 @@ static unsigned int
 mips_function_arg_boundary (machine_mode mode, const_tree type)
 {
   unsigned int alignment;
+  alignment = mips_function_arg_alignment (mode, type);
 
-  alignment = type ? TYPE_ALIGN (type) : GET_MODE_ALIGNMENT (mode);
   if (alignment < PARM_BOUNDARY)
     alignment = PARM_BOUNDARY;
   if (alignment > STACK_BOUNDARY)

--- a/gcc/testsuite/gcc.target/mips/align-1.c
+++ b/gcc/testsuite/gcc.target/mips/align-1.c
@@ -1,0 +1,33 @@
+/* Check that typedef alignment does not affect passing of function
+   parameters. */
+/* { dg-do run { target { "mips*-*-linux*" } } } */
+
+#include <assert.h>
+
+typedef struct ui8
+{
+  unsigned v[8];
+} uint8 __attribute__ ((aligned(64)));
+
+unsigned
+callee (int x, uint8 a)
+{
+  return a.v[0];
+}
+
+uint8
+identity (uint8 in)
+{
+  return in;
+}
+
+int
+main (void)
+{
+  uint8 vec = {{1, 2, 3, 4, 5, 6, 7, 8}};
+  uint8 temp = identity (vec);
+  unsigned temp2 = callee (1, identity (vec));
+  assert (callee (1, temp) == 1);
+  assert (temp2 == 1);
+  return 0;
+}


### PR DESCRIPTION
Implemented a fix for passing overaligned typedef structures in functions. Now, aliased structures have the same alignment as the original structure, making it impossible for an aliased structure to have alignment that is greater than its size.
